### PR TITLE
Drupal Coding standard fixes & code style fixes.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Crop module [![Build Status](https://travis-ci.org/drupal-media/crop.svg?branch=8.x-1.x)](https://travis-ci.org/drupal-media/crop)
 
-Provides basic API for image cropping. This module won't do much by itself. Users should pick one of UI modules that utilize this API.
+Provides basic API for image cropping. This module won't do much by itself. 
+Users should pick one of UI modules that utilize this API.
 
 ## Requirements
 
@@ -12,4 +13,6 @@ No functionality can be tested ATM. Module is still under heavy development.
 
 ## Technical details
 
-Initial discussion can be found on [manual crop issue queue.](https://www.drupal.org/node/2368945).
+Initial discussion can be found on [manual crop issue queue].
+
+[manual crop issue queue]: https://www.drupal.org/node/2368945

--- a/crop.api.php
+++ b/crop.api.php
@@ -13,10 +13,10 @@
 /**
  * Alter the information provided in \Drupal\crop\Annotation\CropEntityProvider.
  *
- * @param $providers
+ * @param array $providers
  *   The array of provider plugins, keyed by the machine-readable name.
  */
-function hook_crop_entity_provider_info_alter(&$providers) {
+function hook_crop_entity_provider_info_alter(array &$providers) {
   $providers['media']['label'] = t('Super fancy provider for media entity!');
 }
 

--- a/crop.module
+++ b/crop.module
@@ -24,7 +24,7 @@ function crop_theme() {
 /**
  * Prepares variables for crop_crop summary template.
  *
- * Default template: crop-crop-summary.twig.html
+ * Default template: crop-crop-summary.twig.html.
  */
 function template_preprocess_crop_crop_summary(&$variables) {
   if (!empty($variables['data']['crop_type'])) {

--- a/modules/crop_media_entity/src/Plugin/Crop/EntityProvider/MediaEntity.php
+++ b/modules/crop_media_entity/src/Plugin/Crop/EntityProvider/MediaEntity.php
@@ -1,6 +1,7 @@
 <?php
 
 /**
+ * @file
  * Contains \Drupal\crop_media_entity\Plugin\EntityProvider\MediaEntity.
  */
 

--- a/src/CropInterface.php
+++ b/src/CropInterface.php
@@ -30,7 +30,7 @@ interface CropInterface extends ContentEntityInterface {
   public function size();
 
   /**
-   * Gets crop anchor (top-left corner of crop area)
+   * Gets crop anchor (top-left corner of crop area).
    *
    * @return array
    *   Array with two keys (x, y) and anchor coordinates as values.
@@ -47,4 +47,5 @@ interface CropInterface extends ContentEntityInterface {
    *   Thrown if entity provider not found.
    */
   public function provider();
+
 }

--- a/src/CropTypeListBuilder.php
+++ b/src/CropTypeListBuilder.php
@@ -62,7 +62,7 @@ class CropTypeListBuilder extends ConfigEntityListBuilder {
     $header['name'] = t('Name');
     $header['description'] = array(
       'data' => t('Description'),
-      'class' => array(RESPONSIVE_PRIORITY_MEDIUM),
+      'class' => [RESPONSIVE_PRIORITY_MEDIUM],
     );
     return $header + parent::buildHeader();
   }
@@ -73,7 +73,7 @@ class CropTypeListBuilder extends ConfigEntityListBuilder {
   public function buildRow(EntityInterface $entity) {
     $row['name'] = array(
       'data' => $this->getLabel($entity),
-      'class' => array('menu-label'),
+      'class' => ['menu-label'],
     );
     $row['description'] = Xss::filterAdmin($entity->description);
     return $row + parent::buildRow($entity);

--- a/src/Entity/Crop.php
+++ b/src/Entity/Crop.php
@@ -139,6 +139,8 @@ class Crop extends ContentEntityBase implements CropInterface {
    * {@inheritdoc}
    */
   public static function baseFieldDefinitions(EntityTypeInterface $entity_type) {
+    $fields = [];
+
     $fields['cid'] = BaseFieldDefinition::create('integer')
       ->setLabel(t('Crop ID'))
       ->setDescription(t('The crop ID.'))
@@ -184,13 +186,14 @@ class Crop extends ContentEntityBase implements CropInterface {
     // given entity type. Saved here for performance reasons in image effects.
     // ---
     // TODO - we are not enforcing uniqueness on this as we want to support more
-    // crops per same image/image_style combination. However, image effect operates
-    // with image URI only, which means we have no mechanism to distinguish between
-    // multiple crops in there. If we really want to support multiple crops we'll
-    // need to override core at least in \Drupal\Core\Image\ImageFactory and
-    // \Drupal\Core\Image\Image. Let's leave this for now and simply load based
-    // on URI only. We can use some semi-smart approach in case there are multiple
-    // crops with same URI for now (first created, last created, ...).
+    // crops per same image/image_style combination. However, image effect
+    // operates with image URI only, which means we have no mechanism to
+    // distinguish between multiple crops in there. If we really want to
+    // support multiple crops we'll need to override core at least,
+    // in \Drupal\Core\Image\ImageFactory and \Drupal\Core\Image\Image.
+    // Let's leave this for now and simply load based on URI only.
+    // We can use some semi-smart approach in case there are multiple crops
+    // with same URI for now (first created, last created, ...).
     $fields['uri'] = BaseFieldDefinition::create('uri')
       ->setLabel(t('URI'))
       ->setDescription(t('The URI of the image crop belongs to.'))

--- a/src/EntityProviderBase.php
+++ b/src/EntityProviderBase.php
@@ -1,6 +1,7 @@
 <?php
 
 /**
+ * @file
  * Contains \Drupal\crop\EntityProviderBase.
  */
 
@@ -25,4 +26,5 @@ abstract class EntityProviderBase extends PluginBase implements EntityProviderIn
    * {@inheritdoc}
    */
   abstract public function uri(EntityInterface $entity);
+
 }

--- a/src/EntityProviderNotFoundException.php
+++ b/src/EntityProviderNotFoundException.php
@@ -9,7 +9,7 @@ namespace Drupal\crop;
 
 /**
  * EntityProviderNotFoundException will be thrown if an non-existing crop entity
- * provider plugin was requested
+ * provider plugin was requested.
  */
 class EntityProviderNotFoundException extends \Exception {
 

--- a/src/Form/CropTypeForm.php
+++ b/src/Form/CropTypeForm.php
@@ -27,8 +27,7 @@ class CropTypeForm extends EntityForm {
       $this->operation == 'add' ?
         $this->t('Add crop type')
         :
-        $form['#title'] = $this->t('Edit %label crop type', array('%label' => $type->label()))
-    ;
+        $form['#title'] = $this->t('Edit %label crop type', array('%label' => $type->label()));
 
     $form['label'] = [
       '#title' => t('Name'),
@@ -96,7 +95,8 @@ class CropTypeForm extends EntityForm {
 
     if ($status == SAVED_UPDATED) {
       drupal_set_message(t('The crop type %name has been updated.', $t_args));
-    } elseif ($status == SAVED_NEW) {
+    }
+    elseif ($status == SAVED_NEW) {
       drupal_set_message(t('The crop type %name has been added.', $t_args));
       $context = array_merge($t_args, array('link' => $this->l(t('View'), new Url('crop.overview_types'))));
       $this->logger('crop')->notice('Added crop type %name.', $context);

--- a/src/Plugin/Crop/EntityProvider/File.php
+++ b/src/Plugin/Crop/EntityProvider/File.php
@@ -1,6 +1,7 @@
 <?php
 
 /**
+ * @file
  * Contains \Drupal\crop\Plugin\EntityProvider\File.
  */
 

--- a/src/Plugin/ImageEffect/CropEffect.php
+++ b/src/Plugin/ImageEffect/CropEffect.php
@@ -165,6 +165,7 @@ class CropEffect extends ConfigurableImageEffectBase implements ContainerFactory
    *
    * @param ImageInterface $image
    *   Image object.
+   *
    * @return \Drupal\Core\Entity\EntityInterface|\Drupal\crop\CropInterface|FALSE
    *   Crop entity or FALSE if crop doesn't exist.
    */

--- a/src/Tests/CropCRUDTest.php
+++ b/src/Tests/CropCRUDTest.php
@@ -37,7 +37,8 @@ class CropCRUDTest extends CropUnitTestBase {
     try {
       $crop_type->save();
       $this->assertTrue(TRUE, 'Crop type saved correctly.');
-    } catch (\Exception $exception) {
+    }
+    catch (\Exception $exception) {
       $this->assertTrue(FALSE, 'Crop type not saved correctly.');
     }
 
@@ -71,7 +72,8 @@ class CropCRUDTest extends CropUnitTestBase {
     try {
       $crop->save();
       $this->assertTrue(TRUE, 'Crop saved correctly.');
-    } catch (\Exception $exception) {
+    }
+    catch (\Exception $exception) {
       $this->assertTrue(FALSE, 'Crop not saved correctly.');
     }
 

--- a/src/Tests/CropEffectTest.php
+++ b/src/Tests/CropEffectTest.php
@@ -24,7 +24,7 @@ class CropEffectTest extends CropUnitTestBase {
   /**
    * Tests manual crop image effect.
    */
-  function testCropEffect() {
+  public function testCropEffect() {
     // Create image to be cropped.
     $file = $this->getTestFile();
     $file->save();
@@ -50,9 +50,9 @@ class CropEffectTest extends CropUnitTestBase {
 
     $this->assertTrue(file_exists($derivative_uri), 'Image derivative file exists on the filesystem.');
 
-    // Test if cropped version looks like expected. Basically loop pixels in derivative
-    // image and check if they look the same as pixels in corresponding region
-    // on original image.
+    // Test if cropped version looks like expected. Basically loop pixels,
+    // in derivative image and check if they look the same as pixels,
+    // in corresponding region on original image.
     $original_image = imagecreatefrompng($file->getFileUri());
     $derivative_image = imagecreatefrompng($derivative_uri);
     $orig_start = $crop->anchor();

--- a/src/Tests/CropEntityProvidersTest.php
+++ b/src/Tests/CropEntityProvidersTest.php
@@ -23,7 +23,9 @@ class CropEntityProvidersTest extends CropUnitTestBase {
    */
   public static $modules = ['crop', 'file', 'image', 'user', 'system'];
 
-
+  /**
+   * {@inheritdoc}
+   */
   protected function setUp() {
     parent::setUp();
 
@@ -34,7 +36,7 @@ class CropEntityProvidersTest extends CropUnitTestBase {
   /**
    * Tests file provider plugin.
    */
-  function testCropEffect() {
+  public function testCropEffect() {
     $file = $this->getTestFile();
     $file->save();
 
@@ -57,7 +59,8 @@ class CropEntityProvidersTest extends CropUnitTestBase {
     try {
       $provider = $crop->provider();
       $this->assertTrue(TRUE, 'File entity provider plugin was found.');
-    } catch (EntityProviderNotFoundException $e) {
+    }
+    catch (EntityProviderNotFoundException $e) {
       $this->assertTrue(FALSE, 'File entity provider plugin was found.');
     }
 

--- a/src/Tests/CropFunctionalTest.php
+++ b/src/Tests/CropFunctionalTest.php
@@ -45,12 +45,15 @@ class CropFunctionalTest extends WebTestBase {
    */
   protected $cropType;
 
+  /**
+   * {@inheritdoc}
+   */
   protected function setUp() {
     parent::setUp();
 
     $this->adminUser = $this->drupalCreateUser(['administer crop types', 'administer image styles']);
 
-    // Create test image style
+    // Create test image style.
     $this->testStyle = $this->container->get('entity.manager')->getStorage('image_style')->create([
       'name' => 'test',
       'label' => 'Test image style',
@@ -62,7 +65,7 @@ class CropFunctionalTest extends WebTestBase {
   /**
    * Tests crop type crud pages.
    */
-  public function testCropTypeCRUD() {
+  public function testCropTypeCrud() {
     // Anonymous users don't have access to crop type admin pages.
     $this->drupalGet('admin/structure/crop');
     $this->assertResponse(403);

--- a/src/Tests/CropUnitTestBase.php
+++ b/src/Tests/CropUnitTestBase.php
@@ -50,6 +50,9 @@ abstract class CropUnitTestBase extends KernelTestBase {
    */
   protected $cropType;
 
+  /**
+   * {@inheritdoc}
+   */
   protected function setUp() {
     parent::setUp();
 
@@ -65,7 +68,7 @@ abstract class CropUnitTestBase extends KernelTestBase {
     $entity_manager->onEntityTypeCreate($entity_manager->getDefinition('crop'));
     $entity_manager->onEntityTypeCreate($entity_manager->getDefinition('file'));
 
-    // Create test image style
+    // Create test image style.
     $uuid = $this->container->get('uuid')->generate();
     $this->testStyle = $this->imageStyleStorage->create([
       'name' => 'test',
@@ -81,7 +84,7 @@ abstract class CropUnitTestBase extends KernelTestBase {
     ]);
     $this->testStyle->save();
 
-    // Create test crop type
+    // Create test crop type.
     $this->cropType = $this->cropTypeStorage->create([
       'id' => 'test_type',
       'label' => 'Test crop type',


### PR DESCRIPTION
I performed a global review of code to hunt standard coding errors and possible worries of coding style. (Scrutinizer & Drupal code sniffer).

Globaly the module is PRETTY CLEAN ! (9.63) ITS INCREDIBLE :100:  https://scrutinizer-ci.com/g/woprrr/crop/badges/quality-score.png?b=8.x-1.x 

I ve found other error (4 errors) then it's hard to fix it, I do not know exactly all that that implies. especially this one on line 26.

``` bash
FILE: ...o/src/modules/contrib/crop/src/Annotation/CropEntityProvider.php
----------------------------------------------------------------------
FOUND 2 ERRORS AFFECTING 2 LINES
----------------------------------------------------------------------
 26 | ERROR | Class property $entity_type should use lowerCamel
    |       | naming without underscores
 30 | ERROR | Doc comment short description must be on a single line,
    |       | further text should be a separate paragraph
----------------------------------------------------------------------
```
