### PR TITLE
Issue #2856282 by Elendev: Add implementation of transformDimensions into CropEffect

### DIFF
--- a/src/Plugin/ImageEffect/CropEffect.php
+++ b/src/Plugin/ImageEffect/CropEffect.php
@@ -70,6 +70,18 @@ class CropEffect extends ConfigurableImageEffectBase implements ContainerFactory
   /**
    * {@inheritdoc}
    */
+  public function transformDimensions(array &$dimensions, $uri) {
+    if ($crop = $this->getCropFromUri($uri)) {
+      $size = $crop->size();
+
+      $dimensions['width'] = $size['width'];
+      $dimensions['height'] = $size['height'];
+    }
+  }
+
+  /**
+   * {@inheritdoc}
+   */
   public function applyEffect(ImageInterface $image) {
     if (empty($this->configuration['crop_type']) || !$this->typeStorage->load($this->configuration['crop_type'])) {
       $this->logger->error('Manual image crop failed due to misconfigured crop type on %path.', ['%path' => $image->getSource()]);
@@ -156,9 +168,22 @@ class CropEffect extends ConfigurableImageEffectBase implements ContainerFactory
    *   Crop entity or FALSE if crop doesn't exist.
    */
   protected function getCrop(ImageInterface $image) {
+    return $this->getCropFromUri($image->getSource());
+  }
+
+  /**
+   * Gets crop entity for the given URI.
+   *
+   * @param $uri
+   *    URI of the image
+   *
+   * @return bool|\Drupal\Core\Entity\EntityInterface|\Drupal\crop\CropInterface|FALSE
+   *    Crop entity or FALSE if crop doesn't exist
+   */
+  protected function getCropFromUri($uri) {
     if (!isset($this->crop)) {
       $this->crop = FALSE;
-      if ($crop = Crop::findCrop($image->getSource(), $this->configuration['crop_type'])) {
+      if ($crop = Crop::findCrop($uri, $this->configuration['crop_type'])) {
         $this->crop = $crop;
       }
     }


### PR DESCRIPTION
Add support of transformDimensions to be able to use the imageStyle's `transformDimensions` method.

To avoid duplication of code, I've made a small refactoring of getCrop to use the new getCropFromUri method.